### PR TITLE
Potential fix for code scanning alert no. 1: DOM text reinterpreted as HTML

### DIFF
--- a/src/components/SettingsButton.tsx
+++ b/src/components/SettingsButton.tsx
@@ -78,7 +78,20 @@ export const SettingsButton: React.FC = () => {
   const handleImageProxyUrlChange = (value: string) => {
     setImageProxyUrl(value);
     if (typeof window !== 'undefined') {
-      localStorage.setItem('imageProxyUrl', value);
+      // Only accept http(s) URLs; refuse other protocols
+      try {
+        const url = new URL(value);
+        if (url.protocol === 'http:' || url.protocol === 'https:') {
+          localStorage.setItem('imageProxyUrl', value);
+        } else {
+          // Optionally set error state or notify user
+          // For now, just clear the input in localStorage if invalid
+          localStorage.removeItem('imageProxyUrl');
+        }
+      } catch {
+        // Invalid URL (parsing failed), remove stored value
+        localStorage.removeItem('imageProxyUrl');
+      }
     }
   };
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -35,7 +35,10 @@ export function processImageUrl(originalUrl: string): string {
   if (!originalUrl) return originalUrl;
 
   const proxyUrl = getImageProxyUrl();
-  if (!proxyUrl) return originalUrl;
+  if (
+    !proxyUrl ||
+    !/^https?:\/\//i.test(proxyUrl)
+  ) return originalUrl;
 
   return `${proxyUrl}${encodeURIComponent(originalUrl)}`;
 }


### PR DESCRIPTION
Potential fix for [https://github.com/uni688/UnicornTV/security/code-scanning/1](https://github.com/uni688/UnicornTV/security/code-scanning/1)

To fix the problem, we need to ensure that untrusted input supplied as the image proxy URL is strictly validated or sanitized before being used as the initial part of an image `src`. The best general solution is to require that the image proxy URL only be an HTTP(S) URL, and to avoid supporting schemes like `data:`, `javascript:`, or others. This can be achieved by validating the URL using the browser’s `URL` API and ensuring its protocol is `http:` or `https:` before saving to `localStorage` or before using it in `processImageUrl`. The best place to apply this is in the handler that saves the image proxy URL (so only validated URLs are used throughout the app). Additionally, for defense in depth, the `processImageUrl` function should refuse to use proxy URLs that do not start with “http” (case-insensitive).

**What to change:**
- In `SettingsButton.tsx`, validate user input in `handleImageProxyUrlChange`—accept only URLs starting with `http://` or `https://`.
- Alternatively, and **additionally for safety**, in `processImageUrl`, validate again before constructing the final URL.
- Both changes should be made in the files and lines shown.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
